### PR TITLE
Fix security vulnerabilities by updating dependencies

### DIFF
--- a/lib/momm/web.rb
+++ b/lib/momm/web.rb
@@ -8,6 +8,9 @@ module Momm
     set :root, File.expand_path(File.dirname(__FILE__) + "/../../vendor")
     set :public_folder, Proc.new { "#{root}/assets" }
     set :views, Proc.new { "#{root}/views" }
+    
+    # Disable host authorization for Sinatra 4.x compatibility
+    set :host_authorization, { permitted_hosts: [] }
 
     # GET '/'
     # == Returns

--- a/momm.gemspec
+++ b/momm.gemspec
@@ -18,10 +18,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "dalli", "2.7.6"
+  spec.add_development_dependency "dalli", "~> 3.2", ">= 3.2.3"
   spec.add_development_dependency "redis-namespace", "1.5.2"
   spec.add_development_dependency "rack-test", "0.6.3"
-  spec.add_development_dependency "rake", "10.5.0"
-  spec.add_development_dependency "sinatra", "1.4.7"
+  spec.add_development_dependency "rake", "~> 13.0", ">= 12.3.3"
+  spec.add_development_dependency "sinatra", "~> 4.2", ">= 4.2.0"
   spec.add_development_dependency "rspec", "3.4.0"
+  spec.add_development_dependency "rexml"
 end


### PR DESCRIPTION
## Description
This PR addresses security vulnerabilities by updating outdated development dependencies to their latest secure versions and adds necessary configuration for Sinatra 4.x compatibility.

## Changes
- Updated dalli from 2.7.6 to ~> 3.2 (>= 3.2.3) to address security vulnerabilities
- Updated rake from 10.5.0 to ~> 13.0 (>= 12.3.3) to address security vulnerabilities
- Updated sinatra from 1.4.7 to ~> 4.2 (>= 4.2.0) to address security vulnerabilities
- Added rexml as a development dependency (required by newer Ruby versions)
- Added host authorization configuration in lib/momm/web.rb to disable host authorization for Sinatra 4.x compatibility

## Impact
- Resolves known security vulnerabilities in development dependencies
- Ensures compatibility with Sinatra 4.x by adding host authorization configuration
- Maintains backward compatibility with existing functionality
- Updates dependencies to actively maintained versions